### PR TITLE
Fixed wrong month name

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -323,7 +323,7 @@
 	"about history title": "Our history",
 	"about cta title": "Do you want to work with us?",
 	"about cta button": "Contact us",
-	"months november": "months november",
+	"months november": "November",
 	"months february": "February",
 	"months march": "March",
 	"months june": "June",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -323,7 +323,7 @@
 	"about history title": "Our history",
 	"about cta title": "Do you want to work with us?",
 	"about cta button": "Contact us",
-	"months november": "months november",
+	"months november": "November",
 	"months february": "February",
 	"months march": "March",
 	"months june": "June",


### PR DESCRIPTION
Replace "months november 2012" by "November 2012"