### PR TITLE
Remove nuts to download desktop client

### DIFF
--- a/src/download.html
+++ b/src/download.html
@@ -12,6 +12,40 @@ pathTo: ..
 from: download
 ---
 
+<script type="text/javascript" charset="UTF-8">
+  function getFields(input, field) {
+      var output = [];
+      input.forEach(function(item) {
+        output.push(item[field]);
+      })
+      return output;
+  }
+
+  function desktopDownload(suffix) {
+    var xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+      if (this.readyState == 4) {
+        if (this.status == 200) {
+          const resp = JSON.parse(this.responseText)
+          const download_urls = getFields(resp.assets, "browser_download_url")
+          var selectedUrl = download_urls.filter(url => {
+            return url.endsWith(suffix)
+          })
+          if (selectedUrl.length > 0) {
+            window.location.href = selectedUrl[0]
+          } else {
+            alert("{{__ 'download link error'}}")
+          }
+        } else {
+          alert("{{__ 'download link error'}}")
+        }
+      }
+    };
+    xhttp.open("GET", "https://api.github.com/repos/cozy-labs/cozy-desktop/releases/latest", true);
+    xhttp.send();
+  }
+</script>
+
 {{> header }}
 
 	<header class="support">
@@ -39,7 +73,7 @@ from: download
 					</div>
 					<div class="row row-justify-center align-center">
 						<div class="col-xs-12 col-lg-8 align-center">
-							<a class="supportList" href="https://nuts.cozycloud.cc/download/channel/stable/osx">
+							<a class="supportList" href="#" onclick="desktopDownload('.dmg')">
 								<figure class="">
 									<img src="{{ pathTo }}/images/icon-48-apple.svg" alt="">
 								</figure>
@@ -48,7 +82,7 @@ from: download
 							</a>
 						</div>
 						<div class="col-xs-12 col-lg-8 align-center">
-							<a class="supportList" href="https://nuts.cozycloud.cc/download/channel/stable/win">
+							<a class="supportList" href="#" onclick="desktopDownload('.exe')">
 								<figure class="">
 									<img src="{{ pathTo }}/images/icon-48-windows.svg" alt="">
 								</figure>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -617,6 +617,7 @@
 	"support get started url": "http://cozy-cloud-help.helpscoutdocs.com/category/99-first-steps-for-the-new-users",
 	"404 title": "404 title",
 	"404 introduction": "404 introduction",
+	"download link error": "Something went wrong, please try again later",
 	"download title": "With Cozy Drive synchronize your Cozy with all your devices",
 	"download introduction": "Synchronize and share your files and photos across all your devices",
 	"download Drive mobile title": "Cozy Drive on your phone",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -574,6 +574,7 @@
     "support get started url": "http://cozy-cloud-help.helpscoutdocs.com/category/99-first-steps-for-the-new-users",
     "404 title": "404 título",
     "404 introduction": "404 introducción",
+    "download link error": "Se ha producido un error. Vuelve a intentarlo más tarde.",
     "download title": "ConCozy Drive sincronice su Cozy con todos sus periféricos",
     "download introduction": "Sincronice y comparta sus archivos y fotos en todos sus periféricos",
     "download Drive mobile title": "Cozy Drive en su teléfono",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -618,6 +618,7 @@
 	"support get started url": "https://support.cozy.io/category/49-premiers-pas",
 	"404 title": "Titre 404",
 	"404 introduction": "Introduction 404",
+	"download link error": "Une erreur est survenue, veuillez réessayer ultérieurement",
 	"download title": "Synchronisez votre Cozy avec tous vos appareils",
 	"download introduction": "Synchronisez et partagez vos fichiers et photos en tous vos appareils",
 	"download Drive mobile title": "Cozy Drive sur votre mobile",


### PR DESCRIPTION
Currently desktop download use a server-side nodejs application to find the appropriate download asset and serve it.
We need to remove that server.

This PR adds a small javascript snippet to the download page to determine the asset name and link and initiate the download.