### PR TITLE
Better features menu link to notes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -216,7 +216,7 @@ from: home
       <div class="usage-image usage-sync"></div>
     </div>
   </div>
-  <div class="panel">
+  <div class="panel" id="notes">
     <div class="usage-wrapper usage-reverse">
       <div class="usage-text">
         <div>

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -49,7 +49,7 @@
 									downloadIOSAlt=(__ 'download Pass Android title')
 							}}
 							{{> app-menu-item
-									href=(join "https://manager.cozycloud.cc/v2/cozy/login?lang=" locale)
+									href=(join "/" locale "/#notes")
 									title=(__ 'features notes name')
 									description=(__ 'features notes title')
 									new=true


### PR DESCRIPTION
This PR replaces the current menu link for notes feature from cozy creation page to notes on the index page
(it's a shame we don't have notes on the feature page)