### PR TITLE
fix: Update required macOS version for Desktop

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -299,7 +299,7 @@
 	"download linux text": "64-bit system",
 	"download macos": "MacOS",
 	"download macos alt": "Logo MacOS",
-	"download macos text": "10.12 Sierra or higher",
+	"download macos text": "10.15 Catalina or higher",
 	"download menu title": "Download",
 	"download mobile": "Mobile",
 	"download mobile alt": "Logo mobile",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -322,7 +322,7 @@
 	"download linux text": "Sistema de 64 bits",
 	"download macos": "MacOS",
 	"download macos alt": "Logo MacOS",
-	"download macos text": "10.12 Sierra o superior",
+	"download macos text": "10.15 Catalina o superior",
 	"download menu title": "download menu title",
 	"download mobile": "Móvil",
 	"download mobile alt": "Logo móvil",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -299,7 +299,7 @@
 	"download linux text": "Système 64 bits",
 	"download macos": "MacOS",
 	"download macos alt": "Logo MacOS",
-	"download macos text": "10.12 Sierra ou supérieure",
+	"download macos text": "10.15 Catalina ou supérieure",
 	"download menu title": "Téléchargement",
 	"download mobile": "Mobile",
 	"download mobile alt": "Logo mobile",


### PR DESCRIPTION
Since we upgraded Deskop's Electron version to v27+, we have lost
compatibility with macOS 10.13 and 10.14.
Compatibility with macOS 10.12 was probably already lost a while back.